### PR TITLE
fix(action): shorten description for Marketplace limit; bump 2.1.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "upkeep",
       "source": "./skills/upkeep-audit",
       "description": "Run the Upkeep repo audit from Claude Code: drift findings by severity plus a self-contained HTML report. Never edits your files.",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "author": {
         "name": "Wei18"
       }

--- a/action.yml
+++ b/action.yml
@@ -1,8 +1,5 @@
 name: Upkeep Audit
-description: >-
-  AI audit crew for repo drift — stale docs, specs that no longer match the
-  code, orphaned assets, broken conventions. Reports findings with evidence;
-  never edits or deletes your files.
+description: AI audit crew for repo drift - finds stale docs, mismatched specs, and orphaned assets. Evidence-based, output-only.
 author: Wei18
 branding:
   icon: search


### PR DESCRIPTION
GitHub Marketplace rejects action descriptions >=125 chars. Shortened to 116 chars and bumped plugin version to 2.1.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)